### PR TITLE
Multiple outputs and types

### DIFF
--- a/comb/synth/pattern_encoding.py
+++ b/comb/synth/pattern_encoding.py
@@ -60,7 +60,6 @@ class PatternEncoding:
         raise NotImplementedError
 
     def P_iropt(self, dce, cse):
-        assert not cse
         P_iropt = []
         if dce:
             P_iropt.append(self.P_dse)
@@ -68,12 +67,14 @@ class PatternEncoding:
             P_iropt.append(self.P_cse)
         return fc.And(P_iropt)
 
-    def P_narrow(self, C, K):
+    def P_narrow(self, C, K, O_order):
         P_narrow = []
         if C:
             P_narrow.append(self.P_comm)
         if K:
             P_narrow.append(self.P_K)
+        if O_order:
+            P_narrow.append(self.P_O_order)
         return fc.And(P_narrow)
 
 

--- a/comb/synth/rule.py
+++ b/comb/synth/rule.py
@@ -64,8 +64,8 @@ class Rule:
     def enum_input_perm(self, PL, PR):
         I = PL[0]
         NI = len(I)
-        NL = len(PL[3])
-        NR = len(PR[3])
+        NL = sum([len(x) for x in PL[3]])
+        NR = sum([len(x) for x in PR[3]])
         for iperm in it.permutations(I):
             map = {i:j for i, j in enumerate(iperm)}
             mapL = {**map, **{i+NI:i+NI for i in range(NL)}}
@@ -74,8 +74,6 @@ class Rule:
 
 
     def ruleL(self, L_IR, L_ISA):
-
-
         #enums patterns
         l_enum = all_prog(self.lhs.enum_CK(), self.lhs.enum_prog)
         r_enum = all_prog(self.rhs.enum_CK(), self.rhs.enum_prog)

--- a/comb/synth/rule_discover.py
+++ b/comb/synth/rule_discover.py
@@ -79,9 +79,8 @@ class RuleDiscovery:
         self.lhs_name_to_id = {comb.qualified_name:i for i, comb in enumerate(self.lhss)}
         self.rhs_name_to_id = {comb.qualified_name:i for i, comb in enumerate(self.rhss)}
 
-    def allT(self, lhs_ops, rhs_ops, max_outputs = 1):
+    def allT(self, lhs_ops, rhs_ops, max_outputs):
         # generate all possible program input and output type combinations
-        assert max_outputs == 1
 
         lop_iTs, lop_oTs = T_count(lhs_ops)
         rop_iTs, rop_oTs = T_count(rhs_ops)

--- a/comb/synth/solver_utils.py
+++ b/comb/synth/solver_utils.py
@@ -55,8 +55,8 @@ def get_model(query, vars, solver_name, logic):
 
 @dataclass
 class Cegis:
-    query: ht.SMTBit
-    synth: ht.SMTBit
+    synth_base: ht.SMTBit
+    synth_constrain: ht.SMTBit
     verif: ht.SMTBit
     E_vars: tp.Iterable['freevars']
     input_vars: tp.Iterable['inputvars']
@@ -74,88 +74,24 @@ class Cegis:
         #assert opts.max_iters > 0
         #print("Query Size:", smt.get_formula_size(query))
         if prev_sol is not None:
-            query = self.query.value
             sol_term = smt.Bool(True)
             for var, val in prev_sol.items():
                 sol_term = smt.And(sol_term, smt.EqualsOrIff(var, val))
-            self.query = ht.SMTBit(smt.And(query, smt.Not(sol_term)))
-        query = self.query.value
-        #get exist vars:
-        E_vars = set(var.value for var in self.E_vars)  # exist_vars
-        A_vars = query.get_free_variables() - E_vars  # forall vars
-
-        with smt.Solver(logic=opts.logic, name=opts.solver_name) as solver:
-            solver.add_assertion(smt.Bool(True))
-
-            # Start with checking all A vals beings 0
-            A_vals = {v: _int_to_pysmt(0, v.get_type()) for v in A_vars}
-            solver.add_assertion(query.substitute(A_vals).simplify())
-            start = timeit.default_timer()
-            for i in it.count(1):
-                if (timeit.default_timer()-start > opts.timeout):
-                    print('TO', flush=True)
-                    #if show_iter:
-                    #    print("TO")
-                    return IterLimitError(), opts.timeout
-
-                if show_iter and i%10==0:
-                    print(f".{i}", end='', flush=True)
-                E_res = solver.solve()
-
-                if not E_res:
-                    t = (timeit.default_timer()-start)
-                    #print('UNSAT',t, flush=True)
-                    if show_iter:
-                        print("UNSAT")
-                    return None, t
-                else:
-                    E_guess = {v: solver.get_value(v) for v in E_vars}
-                    if show_e and i%100==50:
-                        print_e(E_guess)
-                    query_guess = query.substitute(E_guess).simplify()
-                    model = smt.get_model(smt.Not(query_guess), solver_name=opts.solver_name, logic=opts.logic)
-                    if model is None:
-                        t = (timeit.default_timer()-start)
-                        print('SAT',t, flush=True)
-                        if show_iter:
-                            print("SAT")
-                        return E_guess, t
-                    else:
-                        A_vals = {v: model.get_value(v) for v in A_vars}
-                        solver.add_assertion(query.substitute(A_vals).simplify())
-
-    def cegis_new(self, prev_sol, opts: SolverOpts = SolverOpts()):
-        if opts.verbose==2:
-            show_e = True
-            show_iter = True
-        elif opts.verbose:
-            show_e = False
-            show_iter = True
-        else:
-            show_e = False
-            show_iter = False
-        #assert opts.max_iters > 0
-        #print("Query Size:", smt.get_formula_size(query))
-        if prev_sol is not None:
-            synth = self.synth.value
-            sol_term = smt.Bool(True)
-            for var, val in prev_sol.items():
-                sol_term = smt.And(sol_term, smt.EqualsOrIff(var, val))
-            self.synth = ht.SMTBit(smt.And(synth, smt.Not(sol_term)))
-        synth = self.synth.value
+            self.synth_base = ht.SMTBit(smt.And(self.synth_base.value, smt.Not(sol_term)))
+        synth_constrain = self.synth_constrain.value
         verif = self.verif.value
         #get exist vars:
         E_vars = set(var.value for var in self.E_vars)  # exist_vars
-        A_vars = synth.get_free_variables() - E_vars  # forall vars
+        A_vars = synth_constrain.get_free_variables() - E_vars  # forall vars
         input_vars = [var.value for var in self.input_vars]
         dep_vars = A_vars - set(input_vars)
 
         with smt.Solver(logic=opts.logic, name=opts.solver_name) as solver:
-            solver.add_assertion(smt.Bool(True))
+            solver.add_assertion(self.synth_base.value)
 
             # Start with checking all A vals beings 0
             input_vals = {v: _int_to_pysmt(0, v.get_type()) for v in input_vars}
-            solver.add_assertion(synth.substitute(input_vals).simplify())
+            solver.add_assertion(synth_constrain.substitute(input_vals).simplify())
             start = timeit.default_timer()
             for i in it.count(1):
                 if (timeit.default_timer()-start > opts.timeout):
@@ -189,16 +125,13 @@ class Cegis:
                     else:
                         input_vals = {v: model.get_value(v) for v in input_vars}
                         dep_vals = {v: get_var(f"{v}_{i}", v.bv_width()).value for v in dep_vars}
-                        solver.add_assertion(synth.substitute(input_vals).substitute(dep_vals).simplify())
+                        solver.add_assertion(synth_constrain.substitute(input_vals).substitute(dep_vals).simplify())
 
     #enum_fun takes a single solution and enumerates all 'permutations' of that solution to add to the exclude list
-    def cegis_all(self, exclude_prev: bool, opts: SolverOpts = SolverOpts(), new_impl = False):
+    def cegis_all(self, exclude_prev: bool, opts: SolverOpts = SolverOpts()):
         prev = None
         while True:
-            if new_impl:
-                sol, t = self.cegis_new(prev_sol=prev, opts=opts)
-            else:
-                sol, t = self.cegis(prev_sol=prev, opts=opts)
+            sol, t = self.cegis(prev_sol=prev, opts=opts)
             if sol is not None:
                 assert sol != prev
             if opts.log:

--- a/comb/synth/spec_synth.py
+++ b/comb/synth/spec_synth.py
@@ -35,7 +35,20 @@ class SpecSynth(Cegis):
             #Final query:
             #  Exists(L) Forall(V) P_wfp(L) & (P_lib & P_conn) => P_spec
 
-            query = And([
+
+            synth_base = And([
+                self.pat_en.P_iropt(*ir_opts),
+                self.pat_en.P_narrow(*narrow_opts),
+                self.pat_en.P_wfp,
+            ])
+
+            synth_constrain = And([
+                self.pat_en.P_lib, 
+                self.pat_en.P_conn,
+                And(P_spec)
+            ])
+
+            verif = And([
                 self.pat_en.P_iropt(*ir_opts),
                 self.pat_en.P_narrow(*narrow_opts),
                 self.pat_en.P_wfp,
@@ -45,23 +58,9 @@ class SpecSynth(Cegis):
                 )
             ])
 
-            synth = And([
-                self.pat_en.P_iropt(*ir_opts),
-                self.pat_en.P_narrow(*narrow_opts),
-                self.pat_en.P_wfp,
-                self.pat_en.P_lib, 
-                self.pat_en.P_conn,
-                And(P_spec)
-            ])
-
-            verif = fc.Implies(
-                        And([self.pat_en.P_lib, self.pat_en.P_conn]),
-                        And(P_spec)
-                    )
-
             #print(query.serialize())
             E_vars = self.pat_en.E_vars
-            super().__init__(query.to_hwtypes(), synth.to_hwtypes(), verif.to_hwtypes(), E_vars, input_vars)
+            super().__init__(synth_base.to_hwtypes(), synth_constrain.to_hwtypes(), verif.to_hwtypes(), E_vars, input_vars)
 
 
     def exclude_pattern(self, pat:Pattern):
@@ -72,7 +71,7 @@ class SpecSynth(Cegis):
         if not self.pat_en.types_viable:
             print("SPECSYNTH TYPES NOT VIABLE")
             return
-        for sol, info in self.cegis_all(True, opts, new_impl = True):
+        for sol, info in self.cegis_all(True, opts):
             yield self.pat_en.pattern_from_sol(sol)
 
     # Tactic. Generate all the non-permuted solutions.

--- a/demo2.py
+++ b/demo2.py
@@ -1,0 +1,135 @@
+import itertools
+import os
+
+import pytest
+
+from comb import Comb
+from comb.frontend.compiler import compile_program
+from comb.synth.comb_encoding import CombEncoding
+from comb.synth.comm_synth import set_comm
+from comb.synth.pattern import SymOpts
+from comb.synth.rule import Rule, RuleDatabase
+from comb.synth.rule_discover import RuleDiscovery
+from comb.synth.solver_utils import SolverOpts
+from comb.synth.utils import _list_to_counts
+
+from time import time
+
+prog = """\
+Comb ir.add
+In a : BV[2]
+In b : BV[2]
+Out o : BV[2]
+o = bv.add[2](a,b)
+
+Comb ir.ext_add
+In a : BV[2]
+In b : BV[2]
+In ci : BV[1]
+Out o : BV[3]
+zero_1 = bv.const[1,0]()
+zero_2 = bv.const[2,0]()
+a_ext = bv.concat[2,1](a, zero_1)
+b_ext = bv.concat[2,1](b, zero_1)
+ci_ext = bv.concat[1,2](ci, zero_2)
+t = bv.add[3](a_ext,b_ext)
+o = bv.add[3](t,ci_ext)
+
+Comb isa.fa
+In ci : BV[1] 
+In a : BV[1]
+In b : BV[1]
+Out co : BV[1]
+Out s : BV[1]
+a_xor_b = bv.xor[1](a, b)
+s = bv.xor[1](a_xor_b, ci)
+a_and_b = bv.and_[1](a, b)
+t = bv.and_[1](ci, a_xor_b)
+co = bv.or_[1](t, a_and_b)
+
+Comb isa.ha
+In a : BV[1]
+In b : BV[1]
+Out co : BV[1]
+Out s : BV[1]
+s = bv.xor[1](a, b)
+co = bv.and_[1](a, b)
+
+Comb isa.concat2
+In a : BV[1]
+In b : BV[1]
+Out o : BV[2]
+o = bv.concat[1,1](a,b)
+
+Comb isa.concat3
+In a : BV[1]
+In b : BV[1]
+In c : BV[1]
+Out o : BV[3]
+t = isa.concat2(a,b)
+o = bv.concat[2,1](t,c)
+
+Comb isa.split
+In a : BV[2]
+Out o0 : BV[1]
+Out o1 : BV[1]
+o0 = bv.slice[2,0,1](a)
+o1 = bv.slice[2,1,2](a)
+"""
+
+import typing as tp
+
+obj = compile_program(prog)
+ir = [c for c in obj.get_from_ns("ir")]
+isa = [c for c in obj.get_from_ns("isa")]
+print([c.name for c in isa])
+costs = [3,2,1,1,1]
+
+solver_opts = SolverOpts(verbose=0, solver_name='btor', timeout=5, log=False)
+
+def test_genall(LC_test, LC, E, CMP, C, K):
+    if not LC_test:
+        assert not LC
+    print("F:", LC_test, LC, E, CMP, C, K)
+    max_outputs = None
+    maxIR = 2
+    maxISA = 6
+    opMaxIR = None
+    opMaxISA = None
+    dce = 1
+    cse = 1
+    O_order = 1
+    start_time = time()
+    rd = RuleDiscovery(
+        lhss=ir,
+        rhss=isa,
+        maxL=maxIR,
+        maxR=maxISA,
+        opMaxL=opMaxIR,
+        opMaxR=opMaxISA,
+    )
+    ir_opts = (dce, cse)
+    narrow_opts = (C, K, O_order)
+    E_opts = (LC, E, CMP)
+    if LC_test:
+        ga = rd.gen_lowcost_rules(E_opts, ir_opts, narrow_opts, costs, max_outputs, solver_opts)
+    else:
+        ga = rd.gen_all_rules(E_opts, ir_opts, narrow_opts, max_outputs, solver_opts)
+    for ri, rule in enumerate(ga):
+        print("RULE", ri, flush=True)
+        print(rule)
+        print("*"*80)
+    db = rd.rdb
+    for k, info in db.time_info.items():
+        num_unique = info["u"]
+        extra = info['e']
+        sat_time = info['st']
+        extra_time = info['et']
+        assert extra >=0
+        print(f"KIND:{k}, UNIQUE:{num_unique}, DUP: {extra}, ST: {sat_time}, ET: {extra_time}")
+    delta = time()-start_time
+    print("TOTTIME:", delta)
+
+test_genall(1,1,1,1,1,1)
+
+

--- a/tests/test_synth/test_rule_gen.py
+++ b/tests/test_synth/test_rule_gen.py
@@ -89,16 +89,16 @@ ir = [c[N] for c in obj.get_from_ns("ir")]
 isa = [c[N] for c in obj.get_from_ns("isa")]
 print([c.name for c in isa])
 costs = [1,1,2,2]
-@pytest.mark.parametrize("LC_test, LC,E,CMP,C,K,O_order", [
-    (1,1,1,1,1,1,1),
-    (0,0,1,1,1,1,1),
+@pytest.mark.parametrize("LC_test, LC,E,CMP,C,K,O_order,max_outputs", [
+    (1,1,1,1,1,1,1,1),
+    (0,0,1,1,1,1,1,1),
+    (1,1,1,1,1,1,1,None),
 ])
-def test_bit_movement(LC_test, LC, E, CMP, C, K, O_order):
+def test_bit_movement(LC_test, LC, E, CMP, C, K, O_order, max_outputs):
     costs = [1,1,2,2]
     if not LC_test:
         assert not LC
     print("F:", LC_test, LC, E, CMP, C, K, O_order)
-    max_outputs = 1
     maxIR = 3
     maxISA = 3
     opMaxIR = None
@@ -138,7 +138,11 @@ def test_bit_movement(LC_test, LC, E, CMP, C, K, O_order):
     delta = time()-start_time
     print("TOTTIME:", delta)
     if LC_test:
-        assert num_rules == 17
+        if max_outputs is None:
+            assert num_rules == 80
+        else:
+            assert max_outputs == 1
+            assert num_rules == 17
     else: 
         assert num_rules == 20
 

--- a/tests/test_synth/test_rule_gen.py
+++ b/tests/test_synth/test_rule_gen.py
@@ -33,16 +33,16 @@ assert isa[1].comm_info == ([0],) # Neg
 assert isa[2].comm_info == ([0, 1],) # And
 solver_opts = SolverOpts(verbose=0, solver_name='z3', timeout=5, log=False)
 
-@pytest.mark.parametrize("LC_test, LC,E,CMP,C,K", [
-    (1,1,1,1,1,1),
+@pytest.mark.parametrize("LC_test, LC,E,CMP,C,K,O_order", [
+    (1,1,1,1,1,1,1),
     #(1,1,0,1,1),
     #(0,1,1,1,1),
 ])
-def test_genall(LC_test, LC, E, CMP, C, K):
+def test_genall(LC_test, LC, E, CMP, C, K, O_order):
     if not LC_test:
         assert not LC
-    print("F:", LC_test, LC, E, CMP, C, K)
-
+    print("F:", LC_test, LC, E, CMP, C, K, O_order)
+    max_outputs = None
     maxIR = 2
     maxISA = 2
     opMaxIR = None
@@ -59,12 +59,12 @@ def test_genall(LC_test, LC, E, CMP, C, K):
         opMaxR=opMaxISA,
     )
     ir_opts = (dce, cse)
-    narrow_opts = (C, K)
+    narrow_opts = (C, K, O_order)
     E_opts = (LC, E, CMP)
     if LC_test:
-        ga = rd.gen_lowcost_rules(E_opts, ir_opts, narrow_opts, costs, solver_opts)
+        ga = rd.gen_lowcost_rules(E_opts, ir_opts, narrow_opts, costs, max_outputs, solver_opts)
     else:
-        ga = rd.gen_all_rules(E_opts, ir_opts, narrow_opts, solver_opts)
+        ga = rd.gen_all_rules(E_opts, ir_opts, narrow_opts, max_outputs, solver_opts)
     for ri, rule in enumerate(ga):
         print("RULE", ri, flush=True)
         print(rule)
@@ -89,16 +89,16 @@ ir = [c[N] for c in obj.get_from_ns("ir")]
 isa = [c[N] for c in obj.get_from_ns("isa")]
 print([c.name for c in isa])
 costs = [1,1,2,2]
-@pytest.mark.parametrize("LC_test, LC,E,CMP,C,K", [
-    (1,1,1,1,1,1),
-    (0,0,1,1,1,1),
+@pytest.mark.parametrize("LC_test, LC,E,CMP,C,K,O_order", [
+    (1,1,1,1,1,1,1),
+    (0,0,1,1,1,1,1),
 ])
-def test_bit_movement(LC_test, LC, E, CMP, C, K):
+def test_bit_movement(LC_test, LC, E, CMP, C, K, O_order):
     costs = [1,1,2,2]
     if not LC_test:
         assert not LC
-    print("F:", LC_test, LC, E, CMP, C, K)
-
+    print("F:", LC_test, LC, E, CMP, C, K, O_order)
+    max_outputs = 1
     maxIR = 3
     maxISA = 3
     opMaxIR = None
@@ -115,12 +115,12 @@ def test_bit_movement(LC_test, LC, E, CMP, C, K):
         opMaxR=opMaxISA,
     )
     ir_opts = (dce, cse)
-    narrow_opts = (C, K)
+    narrow_opts = (C, K, O_order)
     E_opts = (LC, E, CMP)
     if LC_test:
-        ga = rd.gen_lowcost_rules(E_opts, ir_opts, narrow_opts, costs, solver_opts)
+        ga = rd.gen_lowcost_rules(E_opts, ir_opts, narrow_opts, costs, max_outputs, solver_opts)
     else:
-        ga = rd.gen_all_rules(E_opts, ir_opts, narrow_opts, solver_opts)
+        ga = rd.gen_all_rules(E_opts, ir_opts, narrow_opts, max_outputs, solver_opts)
     num_rules = 0
     for ri, rule in enumerate(ga):
         print("RULE", ri, flush=True)

--- a/tests/test_synth/test_spec_synth.py
+++ b/tests/test_synth/test_spec_synth.py
@@ -86,12 +86,12 @@ BV = GlobalModules['bv']
     (3, 1, 1, 18),
 ])
 def test_add(pat_en_t, num_adds, C, K, num_sols):
-    N, dce, cse = 32, 0, 0
+    N, dce, cse, O_order = 32, 0, 0, 1
     obj = compile_program(add_file)
     spec = obj.get("test",f"add{num_adds+1}")[N]
     ops = [BV.add[N]] * num_adds
     ir_opts = (dce, cse)
-    narrow_opts = (C,K)
+    narrow_opts = (C,K,O_order)
     sq = SpecSynth(
         spec, 
         ops, 
@@ -150,12 +150,12 @@ o0 = bv.sub[N](x, y)
     (1, 9),
 ])
 def test_same_op(pat_en_t, K, num_sols):
-    N, C, dce, cse = 4, 0, 1, 0
+    N, C, dce, cse, O_order = 4, 0, 1, 0, 1
     obj = compile_program(sameop_f)
     spec = obj.get("test", "sameop")[N]
     ops = [BV.not_[N]]*4 + [BV.sub[N]]
     ir_opts = (dce, cse)
-    narrow_opts = (C,K)
+    narrow_opts = (C,K,O_order)
     sq = SpecSynth(
         spec, 
         ops, 
@@ -211,12 +211,12 @@ o = t2
     #DepthEncoding,
 ])
 def test_c_fma(pat_en_t):
-    N, C, K, dce, cse = 16, 0, 0, 0, 0
+    N, C, K, dce, cse, O_order = 16, 0, 0, 0, 0, 1
     obj = compile_program(c_fma_obj)
     spec = obj.get("test", "c_fma")[N]
     ops = [BV.abs_const[N], BV.add[N], BV.mul[N]]
     ir_opts = (dce, cse)
-    narrow_opts = (C,K)
+    narrow_opts = (C,K,O_order)
     sq = SpecSynth(
         spec, 
         ops, 
@@ -268,7 +268,7 @@ import hwtypes as ht
     #DepthEncoding,
 ])
 def test_fulladder(pat_en_t):
-    N, C, K, dce, cse = 1, 1, 1, 1, 0
+    N, C, K, dce, cse, O_order = 1, 1, 1, 1, 0, 0
     obj = compile_program(fa_f)
     spec = obj.get("test", "fa")
     one, zero = ht.SMTBitVector[1](1), ht.SMTBitVector[1](0)
@@ -276,7 +276,7 @@ def test_fulladder(pat_en_t):
     print(spec.evaluate(one, zero, one))
     ops = [BV.xor[N]]*2 + [BV.and_[N]]*2 + [BV.or_[N]]
     ir_opts = (dce, cse)
-    narrow_opts = (C,K)
+    narrow_opts = (C,K,O_order)
     sq = SpecSynth(
         spec, 
         ops, 
@@ -319,12 +319,12 @@ import hwtypes as ht
     #DepthEncoding,
 ])
 def test_add_ext(pat_en_t):
-    N, C, K, dce, cse = 4, 1, 1, 1, 0
+    N, C, K, dce, cse, O_order = 4, 1, 1, 1, 0, 1
     obj = compile_program(add_ext_f)
     spec = obj.get("test", "add_ext")[N]
     ops = [BV.concat[N,1]]*2 + [BV.slice[N,N-1,N]]*2 + [BV.add[N+1]]
     ir_opts = (dce, cse)
-    narrow_opts = (C,K)
+    narrow_opts = (C,K,O_order)
     sq = SpecSynth(
         spec, 
         ops, 
@@ -366,12 +366,12 @@ o = i1
     # DepthEncoding,
 ])
 def test_sub_sub(pat_en_t):
-    N, C, K, dce, cse = 16, 1, 1, 1, 0
+    N, C, K, dce, cse, O_order = 16, 1, 1, 1, 0, 1
     obj = compile_program(bad)
     spec = obj.get("bad", "id2")[N]
     ops = [BV.sub[N]]*2
     ir_opts = (dce, cse)
-    narrow_opts = (C,K)
+    narrow_opts = (C,K, O_order)
     sq = SpecSynth(
         spec, 
         ops, 


### PR DESCRIPTION
This change is actually two in one. First, it adds multiple outputs and output types. Second, it cleans up the cegis code. The cegis query is separated into formulas for synth_base, synth_constrain, and verif. Synth_base must always hold for synthesized programs (well formed, narrowing, etc.), and the synth_constrain is ANDed on top of the base query in every cegis iteration to add each counterexample functionality constraint. Verif is the full original formula, used for the verification step. 